### PR TITLE
add GitHub Action status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 <hr>
 
+[![Build](https://github.com/Belco90/octoclairvoyant/actions/workflows/build.yml/badge.svg)](https://github.com/Belco90/octoclairvoyant/actions/workflows/build.yml)
+[![Lint](https://github.com/Belco90/octoclairvoyant/actions/workflows/lint.yml/badge.svg)](https://github.com/Belco90/octoclairvoyant/actions/workflows/lint.yml)
+
 ### Main Features:
 
 - Search repositories and pick a version range


### PR DESCRIPTION
## Changes

- Add GitHub Action status badges to README

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Might be nice to showoff our our passing builds and lint status in the README.

If you don't want badges, feel free to close the PR. 😉 