### PR TITLE
improve call to action text on about page

### DIFF
--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -41,11 +41,11 @@ const MainSection = () => {
         <Flex justify="center" align="center">
           <NextLink href="/">
             <Button bg="gray.700" color="white" _hover={{ bg: 'gray.900' }}>
-              Check it out!
+              Try me now!
             </Button>
           </NextLink>
           <Link href="#features" ml={4} color="gray.700">
-            Read more
+            Feature list
           </Link>
         </Flex>
       </Stack>


### PR DESCRIPTION
## Changes

- Improve call-to-action text

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

The new text is clearer on the desired action "Try me now!", and also makes it clearer where clicking the link next to the button will take the reader.