### PR TITLE
Use one sentence per line, plus minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Well, the app will do its best and keep every single category of changes receive
 Last but not least: sort the groups by priority.
 As mentioned in the intro, the group of changes we should worry about the most is **breaking changes**.
 Features and Bug Fixes will come next, but what about those groups out of SemVer?
-Well, they'll come after SemVer one without any specific order, except some low priority groups as "Credits", "Thanks"or "Artifacts".
+Well, they'll come after SemVer one without any specific order, except some low priority groups as "Credits", "Thanks" or "Artifacts".
 So the final sorting will be:
 
 1. BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -30,73 +30,74 @@
 
 ### Motivation
 
-In January
-2020 [GitHub announced a shortcut to compare across two releases](https://github.blog/changelog/2020-01-13-shortcut-to-compare-across-two-releases/)
-. This shortcut basically leaves you
-to [pick a release version to compare with from another release version working as base](https://help.github.com/en/github/administering-a-repository/comparing-releases)
-. Then you'll see a diff of the code between those two versions. This is a nice addition, so you can see at once all
-code changes between a range of versions. However, this is not what I expected at all or what I would find most useful
-when comparing releases.
+In January 2020 [GitHub announced a shortcut to compare across two releases](https://github.blog/changelog/2020-01-13-shortcut-to-compare-across-two-releases/).
+This shortcut basically leaves you to [pick a release version to compare with from another release version working as base](https://help.github.com/en/github/administering-a-repository/comparing-releases).
+Then you'll see a diff of the code between those two versions.
+This is a nice addition, so you can see at once all code changes between a range of versions.
+However, this is not what I expected at all or what I would find most useful when comparing releases.
 
-What did I expect then? I spend a lot of time comparing releases, either for upgrading dependencies at work or in my
-personal projects. Or even just to be up to date about some library updates. This process is tedious, specially if there
-are a lot of releases between base and target versions as you need to paginate between multiple pages. I usually do this
-process over GitHub releases tab or going through the `CHANGELOG.md` if available. Usually I'm interested in looking for
-breaking changes more than any other kind of changes.
+What did I expect then?
+I spend a lot of time comparing releases, either for upgrading dependencies at work or in my personal projects.
+Or even just to be up to date about some library updates.
+This process is tedious, specially if there are a lot of releases between base and target versions as you need to paginate between multiple pages.
+I usually do this process over GitHub releases tab or going through the `CHANGELOG.md` if available.
+Usually I'm interested in looking for breaking changes more than any other kind of changes.
 **So why not compare changelogs through releases descriptions filtering, grouping and sorting what really matters?**
 
 That's what Octoclairvoyant does for you with their ability to gain information through extrasensory perception!
-It retrieves all the releases description available from a repo, and leaves you to filter them by base and target
-versions. Then, it will **parse, normalize, group and sort** those changes for you.
+It retrieves all the releases description available from a repo, and leaves you to filter them by base and target versions.
+Then, it will **parse, normalize, group and sort** those changes for you.
 
-But how? Well, there is no mystery on retrieving those descriptions from GitHub right? So let's see those previous
-points in detail:
+But how?
+Well, there is no mystery on retrieving those descriptions from GitHub right?
+So let's see those previous points in detail:
 
 ##### Parsing
 
-This is the most complex process of the app. Even if there is a big parsing step at first, after some other processes
-there are also some additional parsings too. This is done with [unified js](https://unifiedjs.com/), an amazing content
-compiler to syntax tree. It turns out that this powerful library is heavily used by `mdx-js`, `prettier` or `gatsby`!
-So what's the process here? I receive Markdown from GitHub releases, and I want to output React elements, so the process
-is something like this:
+This is the most complex process of the app.
+Even if there is a big parsing step at first, after some other processes there are also some additional parsings too.
+This is done with [unified js](https://unifiedjs.com/), an amazing content compiler to syntax tree.
+It turns out that this powerful library is heavily used by `mdx-js`, `prettier` or `gatsby`!
+So what's the process here?
+I receive Markdown from GitHub releases, and I want to output React elements, so the process is something like this:
 
 > MD --> MDAST --> manipulation explained in steps below --> HTML --> React
 
 The idea behind this is:
 
 1. Convert to MDAST (**M**ark**d**own **AST**) to manipulate the content.
-2. Look for interesting content: MD headings, so descriptions can be classified properly. This is when **normalizing**
-   and **grouping** happens.
-3. When descriptions are grouped, convert them to HTML and apply some improvements (highlight GitHub references and code
-   blocks).
+2. Look for interesting content: MD headings, so descriptions can be classified properly. This is when **normalizing** and **grouping** happens.
+3. When descriptions are grouped, convert them to HTML and apply some improvements (highlight GitHub references and code blocks).
 4. Finally, convert to React to avoid rendering the HTML through `dangerouslySetInnerHTML`.
 
 ##### Normalizing
 
-Semantic Versioning is nice. It's easy to differentiate between changes level just looking at the number position at the
-version. Though now everyone refers to each change level in the same way. The 3 changes levels in SemVer are:
+Semantic Versioning is nice.
+It's easy to differentiate between changes level just looking at the number position at the version.
+Though now everyone refers to each change level in the same way.
+The 3 changes levels in SemVer are:
 
 - Major <--> Breaking Changes
 - Minor <--> Features
 - Patch <--> Bug Fixes
 
-This is one of the reasons Octoclairvoyant will normalize the different levels of changes, so it makes sure all the
-changes under the same level can be grouped properly. Obviously, it needs to normalize different cases, spacing or
-wording, as one repo could refer to patch level as "bugfix" and another one as "BUG FIXES".
+This is one of the reasons Octoclairvoyant will normalize the different levels of changes, so it makes sure all the changes under the same level can be grouped properly.
+Obviously, it needs to normalize different cases, spacing or wording, as one repo could refer to patch level as "bugfix" and another one as "BUG FIXES".
 
 ##### Grouping
 
-At the parsing step where the Markdown is converted into Markdown AST, it's best opportunity to group changes after
-being normalized. This implies put all Breaking Changes together, Features together and so on. What if the group doesn't
-belong to SemVer though? Well, the app will do its best and keep every single category of changes received, and group
-them if several found.
+At the parsing step where the Markdown is converted into Markdown AST, it's best opportunity to group changes after being normalized.
+This implies put all Breaking Changes together, Features together and so on.
+What if the group doesn't belong to SemVer though?
+Well, the app will do its best and keep every single category of changes received, and group them if several are found.
 
 ##### Sorting
 
-Last but not least: sort the groups by priority. As mentioned in the intro, the group of changes we should worry about
-the most is **breaking changes**. Features and Bug Fixes will come next, but what about those groups out of SemVer?
-Well, they'll come after SemVer one without any specific order, except some low priority groups as "Credits", "Thanks"
-or "Artifacts". So the final sorting will be:
+Last but not least: sort the groups by priority.
+As mentioned in the intro, the group of changes we should worry about the most is **breaking changes**.
+Features and Bug Fixes will come next, but what about those groups out of SemVer?
+Well, they'll come after SemVer one without any specific order, except some low priority groups as "Credits", "Thanks"or "Artifacts".
+So the final sorting will be:
 
 1. BREAKING CHANGES
 2. Features
@@ -106,7 +107,7 @@ or "Artifacts". So the final sorting will be:
 6. Thanks
 7. Artifacts
 
-### Future Features:
+### Future features:
 
 - [x] Autocomplete repo URL input
 - [x] Retrieve more releases when repo has more than 100 available (pagination)


### PR DESCRIPTION
## Changes

- Use one sentence per line pattern for Markdown prose
- Reduce heading capitalization
- Fix up bad whitespace just after the GitHub blog links
- Fix up grammar in one sentence

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

I find that using one sentence per line makes future editing of the Markdown prose a lot easier.
You can re-arrange content in a much cleaner way.
Also you get a visual reminder if your sentences are too long.