### PR TITLE
Create bug and feature issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug report
+about: Report a bug
+labels: 'bug'
+---
+
+## Describe the bug
+
+## Give the steps to reproduce
+
+## Have you thought of a possible solution?
+
+## Do you want to help fix the bug?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.md
@@ -1,0 +1,11 @@
+---
+name: Feature suggestion
+about: Suggest a new feature
+labels: 'enhancement'
+---
+
+## What feature would you like to have?
+
+## What problem will be solved by having the feature?
+
+## Do you want to help making the feature?


### PR DESCRIPTION
## Changes

- Create a bug report template
- Create a feature suggestion template
- Prevent contributors/bug reporters from opening a blank issue with `config.yml` file

## Context

Having a template helps bug reporters or contributors to give the correct information.
Both issue templates will use an appropriate label for their respective issues.

I've also made it so that contributors cannot open a empty issue, so they must use either the bug report template, or feature suggestion template.

Feel free to suggest a different wording. 😉 