### PR TITLE
Update Prettier to v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jest": "27.0.1",
     "lint-staged": "10.5.4",
     "pinst": "2.1.6",
-    "prettier": "2.2.1",
+    "prettier": "2.3.0",
     "typescript": "4.2.4"
   },
   "browserslist": {

--- a/src/components/RepositoryReleasesChangelog.tsx
+++ b/src/components/RepositoryReleasesChangelog.tsx
@@ -72,15 +72,17 @@ const RepositoryReleasesChangelog = ({
   fromVersion,
   toVersion,
 }: RepositoryReleasesChangelogProps) => {
-  const [filteredReleases, setFilteredReleases] = useState<Release[] | null>(
-    null
-  )
+  const [filteredReleases, setFilteredReleases] =
+    useState<Release[] | null>(null)
 
-  const { processedReleases, isProcessing } = useProcessReleases(
-    filteredReleases
-  )
+  const { processedReleases, isProcessing } =
+    useProcessReleases(filteredReleases)
 
-  const { data: releases, isLoading, isFetched } = useReleasesQuery({
+  const {
+    data: releases,
+    isLoading,
+    isFetched,
+  } = useReleasesQuery({
     repository,
   })
 

--- a/src/components/RepositorySearchCombobox.tsx
+++ b/src/components/RepositorySearchCombobox.tsx
@@ -69,7 +69,7 @@ const RepositorySearchCombobox = ({
     },
     onSelectedItemChange: ({ selectedItem }) => {
       setIsTyping(false)
-      onSelect((selectedItem as unknown) as Repository)
+      onSelect(selectedItem as unknown as Repository)
     },
   })
 

--- a/src/contexts/comparator-context.tsx
+++ b/src/contexts/comparator-context.tsx
@@ -33,12 +33,10 @@ interface FiltersQuerystring {
   to?: string | null
 }
 
-const ComparatorStateContext = createContext<
-  ComparatorStateContextValue | undefined
->(undefined)
-const ComparatorUpdaterContext = createContext<
-  ComparatorUpdaterContextValue | undefined
->(undefined)
+const ComparatorStateContext =
+  createContext<ComparatorStateContextValue | undefined>(undefined)
+const ComparatorUpdaterContext =
+  createContext<ComparatorUpdaterContextValue | undefined>(undefined)
 
 type InitStatus = 'mount' | 'loading' | 'done'
 

--- a/src/contexts/github-auth-provider.tsx
+++ b/src/contexts/github-auth-provider.tsx
@@ -10,9 +10,8 @@ type GithubAuthContextValue = {
 const GithubAuthContext = createContext<GithubAuthContextValue | null>(null)
 
 function GithubAuthProvider(props: any) {
-  const [accessToken, setAccessToken] = useState<string | null | undefined>(
-    getGithubAccessToken
-  )
+  const [accessToken, setAccessToken] =
+    useState<string | null | undefined>(getGithubAccessToken)
 
   useEffect(() => {
     setGithubAccessToken(accessToken)

--- a/src/hooks/useProcessDescriptionMdast.ts
+++ b/src/hooks/useProcessDescriptionMdast.ts
@@ -53,10 +53,8 @@ function useProcessDescriptionMdast({
   description,
   componentsMapping,
 }: HookArgs): HookReturnedValue {
-  const [
-    processedDescription,
-    setProcessedDescription,
-  ] = useState<ReactNode | null>(null)
+  const [processedDescription, setProcessedDescription] =
+    useState<ReactNode | null>(null)
 
   const [isProcessing, setIsProcessing] = useState(true)
 

--- a/src/hooks/useProcessReleases.ts
+++ b/src/hooks/useProcessReleases.ts
@@ -106,10 +106,8 @@ interface UseProcessReleasesReturn {
 function useProcessReleases(
   releases: Release[] | null
 ): UseProcessReleasesReturn {
-  const [
-    processedReleases,
-    setProcessedReleases,
-  ] = useState<ProcessedReleasesCollection | null>(null)
+  const [processedReleases, setProcessedReleases] =
+    useState<ProcessedReleasesCollection | null>(null)
   const [isProcessing, setIsProcessing] = useState(false)
 
   useEffect(

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,9 +14,11 @@ export type RepositoryQueryParams = {
   owner: string
 }
 
-export type Repository = RestEndpointMethodTypes['repos']['get']['response']['data']
+export type Repository =
+  RestEndpointMethodTypes['repos']['get']['response']['data']
 
-export type Release = RestEndpointMethodTypes['repos']['getRelease']['response']['data']
+export type Release =
+  RestEndpointMethodTypes['repos']['getRelease']['response']['data']
 
 export type ReleaseLike = Omit<Release, 'description'>
 

--- a/src/next-seo.config.ts
+++ b/src/next-seo.config.ts
@@ -10,8 +10,7 @@ const DefaultSEO: DefaultSeoProps = {
     title: `${SITE_TITLE}: ${FULL_DESCRIPTION}`,
     images: [
       {
-        url:
-          'https://raw.githubusercontent.com/belco90/octoclairvoyant/main/public/mascot-logo.png',
+        url: 'https://raw.githubusercontent.com/belco90/octoclairvoyant/main/public/mascot-logo.png',
         width: 516,
         height: 516,
         alt: 'Octoclairvoyant mascot reading a crystal ball',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5720,10 +5720,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
-  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+prettier@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
+  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
 
 pretty-format@^26.0.0, pretty-format@^26.6.2:
   version "26.6.2"


### PR DESCRIPTION
## Changes

- Use Prettier 2.3.0
- Format files with the newer version of Prettier

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

You closed an earlier Renovate bot upgrade to Prettier `2.3.0`, so maybe you really don't want this update. But I figured I'd try again. 😄 

If you don't want to upgrade, please close the PR, and also explain why you don't want to upgrade now, so that I know the reasoning. 😄 