### PR TITLE
Automerge lockfile updates with Renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true
   },
   "internalChecksFilter": "strict",
   "packageRules": [


### PR DESCRIPTION
## Changes

- Tell Renovate bot to automerge lockfile updates

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

I figure we can try out Renovate automerge on the relatively low risk lockfile updates.

Before merging this PR, you need to have setup "Require status checks to pass" in the branch protection rules for the `main` branch on this repository. So the boxes for the Vercel deployment, lint and build should all be ticked.
That way Renovate will only automerge if all three tests pass.

The GitHub docs explain how to manage your branch protection rules: https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule