### PR TITLE
Use isExternal prop for repo link, improve title

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,7 +32,11 @@ const Footer = () => {
               </Link>
             </Box>
             <Box as="span">-</Box>
-            <Link href={REPO_URL} title="GitHub repo link">
+            <Link
+              href={REPO_URL}
+              isExternal
+              title="Octoclairvoyant repository on GitHub"
+            >
               GitHub
             </Link>
           </HStack>


### PR DESCRIPTION
## Changes

- Open link to Octoclairvoyant repository in new browser window
- Use a more descriptive title on hover over link

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Just fixing some small stuff.