### PR TITLE
Use branch automerge, automerge ESLint + Prettier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, renovate/**]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, renovate/**]
   pull_request:
     branches: [main]
 

--- a/renovate.json
+++ b/renovate.json
@@ -6,12 +6,19 @@
     "enabled": true,
     "automerge": true
   },
+  "automergeType": "branch",
   "internalChecksFilter": "strict",
   "packageRules": [
     {
       "description": "Wait 3 days before creating a npm update PR",
       "matchDatasources": ["npm"],
       "stabilityDays": 3
+    },
+    {
+      "description": "Automerge ESLint and Prettier updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePatterns": ["eslint", "prettier"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Changes

- Run tests on push to `renovate/**` branches
- Automerge silently when `renovate/**` branch passes tests
- Add new config that automerges ESLint and Prettier updates if they pass tests

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

The idea of this PR is to make automerging the allowed package updates and the lockfile refresh as silent as possible.

Renovate can now run the tests on the `renovate/**` branches first, if test pass, Renovate will automerge to the `main` branch without creating a PR. If any tests fail, Renovate will create a PR for us to review.

I think it's safe to automerge Prettier and/or ESLint package updates if the test pass, as most of the times we don't need to change the code. If we do need to change the code based on the linter suggestions, it's a manual job anyways.

Let me know if you like this! 😄

Renovate Docs for settings:

- https://docs.renovatebot.com/configuration-options/#automergetype
- https://docs.renovatebot.com/configuration-options/#matchdeptypes
- https://docs.renovatebot.com/configuration-options/#matchpackagepatterns