### PR TITLE
Cache yarn packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
       - name: Install dependencies with yarn
         run: yarn

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "yarn"
 
       - name: Install dependencies with yarn
         run: yarn


### PR DESCRIPTION
## Changes

- Cache yarn packages on our GitHub Action runners

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

It's easy to add caching now, as it's built-in to the action.
Used to be you had to use a separate caching action. 😄 

Important note from [actions/setup-node v2.2.0 release notes](https://github.com/actions/setup-node/releases/tag/v2.2.0):

> Yarn caching handles both yarn versions: 1 or 2.
>
>    At the moment, only `lock` files in the project root are supported.