### PR TITLE
Stop Vercel for GitHub commenting on PRs and commits

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
## Changes

- Create `vercel.json` file
- Configure Vercel for GitHub to stop commenting on PRs and commits

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

I find that the Vercel for GitHub integration is way too noisy, what with it commenting on every PR and every push to `main`.
This PR makes it so that the integration will not comment anymore.

We can still view the deployment preview, but it's not posted in a comment, but near the PR checks part of the PR now.

Vercel documentation:

- https://vercel.com/support/articles/how-to-prevent-vercel-github-comments
- https://vercel.com/docs/configuration#git-integrations