### PR TITLE
Use sticky positioning for changelog headings

### DIFF
--- a/src/components/RepositoryReleasesChangelog.tsx
+++ b/src/components/RepositoryReleasesChangelog.tsx
@@ -49,7 +49,15 @@ const ReleaseChangelogGroup = ({
   return (
     <Box key={title}>
       {shouldShowTitle && (
-        <Heading as="h2" size="xl" mb={4} textTransform={textTransform}>
+        <Heading
+          as="h2"
+          size="xl"
+          bg="white"
+          mb={4}
+          py={4}
+          textTransform={textTransform}
+          sx={{ position: 'sticky', top: '0px' }}
+        >
           {title}
         </Heading>
       )}

--- a/src/components/RepositoryReleasesChangelog.tsx
+++ b/src/components/RepositoryReleasesChangelog.tsx
@@ -56,7 +56,8 @@ const ReleaseChangelogGroup = ({
           mb={4}
           py={4}
           textTransform={textTransform}
-          sx={{ position: 'sticky', top: '0px' }}
+          position="sticky"
+          top={0}
         >
           {title}
         </Heading>


### PR DESCRIPTION
## Changes

- Use `position="sticky"` and `top={0}` to make the heading sticky
- Use `bg="white"` and `py={4}` so there's whitespace separating the scrolling text and the heading

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Fixes #147.

The idea here is that the changelog heading for the section you're in remains visible while scrolling.
If you reach a newer heading, the old heading is "pushed out of the way".

According to https://caniuse.com/css-sticky we do not need to use `-webkit-sticky` anymore to get this to work properly on iOS Safari. But we should test this on iOS Safari 14 to make sure before we merge this to `main`. 😉