### PR TITLE
Improve header component

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -113,9 +113,8 @@ const Header = (props: BoxProps) => {
       as="header"
       zIndex="banner"
       {...props}
-      // TODO: borderTop should be 4px when on iPhones
-      borderTop="8px"
-      borderColor="fuchsia.700"
+      borderTop={{ base: '4px', sm: '8px' }}
+      borderColor={{ base: 'fuchsia.700', sm: 'fuchsia.700' }}
     >
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -114,6 +114,9 @@ const Header = (props: BoxProps) => {
       {...props}
       borderTopWidth={{ base: '4px', sm: '8px' }}
       borderColor="fuchsia.700"
+      // TODO: Remove borderBottomWidth and borderBottomColor once we fix the issue
+      borderBottomWidth="8px"
+      borderBottomColor="sky.700"
     >
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -44,7 +44,7 @@ const MenuLink = ({
       color="primaryTextLightmode"
       borderBottomWidth="4px"
       // TODO: If link is not the active element, borderColor should equal header/drawer background
-      borderColor={isActive ? 'fuchsia.300' : 'white'}
+      borderColor={isActive ? 'fuchsia.300' : 'none'}
       fontWeight="black"
       fontSize={{ base: '2xl', md: 'lg' }}
       _hover={{

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ const MenuLink = ({
     <RouteLink
       href={href}
       color="primaryTextLightmode"
-      borderBottomWidth="4px"
+      borderBottomWidth={isActive ? '4px' : 'none'}
       borderColor={isActive ? 'fuchsia.400' : 'fuchsia.200'}
       fontWeight="black"
       fontSize={{ base: '2xl', md: 'lg' }}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -113,7 +113,7 @@ const Header = (props: BoxProps) => {
       zIndex="banner"
       {...props}
       borderTop={{ base: '4px', sm: '8px' }}
-      borderColor={{ base: 'fuchsia.700', sm: 'fuchsia.700' }}
+      borderColor="fuchsia.700"
     >
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -112,7 +112,7 @@ const Header = (props: BoxProps) => {
       as="header"
       zIndex="banner"
       {...props}
-      borderTop={{ base: '4px', sm: '8px' }}
+      borderTopWidth={{ base: '4px', sm: '8px' }}
       borderColor="fuchsia.700"
     >
       <FluidContainer py={5}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -131,8 +131,7 @@ const Header = (props: BoxProps) => {
               color="primaryTextLightmode"
               letterSpacing="tight"
               fontWeight="black"
-              // TODO: fontSize should be 16 px on iPhones
-              fontSize="36px"
+              fontSize={{ base: '16px', sm: '36px' }}
             >
               Octoclairvoyant
             </Heading>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -41,13 +41,16 @@ const MenuLink = ({
   return (
     <RouteLink
       href={href}
-      color="white"
-      borderBottomWidth={isActive ? '4px' : 'none'}
-      borderColor={isActive ? 'primary.500' : 'none'}
+      color="primaryTextLightmode"
+      borderBottomWidth="4px"
+      // TODO: If link is not the active element, borderColor should equal header/drawer background
+      borderColor={isActive ? 'fuchsia.300' : 'white'}
+      fontWeight="black"
       fontSize={{ base: '2xl', md: 'lg' }}
       _hover={{
         textDecoration: 'none',
-        color: isActive ? 'none' : 'primary.300',
+        borderBottomColor: 'fuchsia.500',
+        color: isActive ? 'none' : 'primaryTextLightmode',
       }}
       width={linkWidth}
       aria-current={isActive ? 'page' : undefined}
@@ -84,14 +87,14 @@ const HeaderLinks = () => {
         aria-label="Toggle menu"
         icon={<Icon as={FaBars} />}
         variant="unstyled"
-        colorScheme="gray.50"
-        size="sm"
+        colorScheme="coolGray.900"
+        size="lg"
         onClick={onToggle}
       />
       <Drawer placement="right" isOpen={isOpen} size="full" onClose={onClose}>
         <DrawerOverlay />
-        <DrawerContent py={8} backgroundColor="gray.700">
-          <DrawerCloseButton color="gray.50" />
+        <DrawerContent py={8} backgroundColor="coolGray.100">
+          <DrawerCloseButton color="coolGray.900" size="lg" />
           <DrawerBody>
             <Flex justify="center" direction="column" h="full">
               {linksInner}
@@ -106,7 +109,14 @@ const HeaderLinks = () => {
 const Header = (props: BoxProps) => {
   const isClientSide = useIsClientSide()
   return (
-    <Box as="header" bg="gray.700" color="white" zIndex="banner" {...props}>
+    <Box
+      as="header"
+      zIndex="banner"
+      {...props}
+      // TODO: borderTop should be 4px when on iPhones
+      borderTop="8px"
+      borderColor="fuchsia.700"
+    >
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">
           <Flex alignItems="center">
@@ -119,9 +129,11 @@ const Header = (props: BoxProps) => {
               />
             </Box>
             <Heading
+              color="primaryTextLightmode"
               letterSpacing="tight"
               fontWeight="black"
-              fontSize={{ base: 'md', md: 'xl', lg: '4xl' }}
+              // TODO: fontSize should be 16 px on iPhones
+              fontSize="36px"
             >
               Octoclairvoyant
             </Heading>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,8 +43,7 @@ const MenuLink = ({
       href={href}
       color="primaryTextLightmode"
       borderBottomWidth="4px"
-      // TODO: If link is not the active element, borderColor should equal header/drawer background
-      borderColor={isActive ? 'fuchsia.300' : 'none'}
+      borderColor={isActive ? 'fuchsia.400' : 'fuchsia.200'}
       fontWeight="black"
       fontSize={{ base: '2xl', md: 'lg' }}
       _hover={{

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -114,9 +114,6 @@ const Header = (props: BoxProps) => {
       {...props}
       borderTopWidth={{ base: '4px', sm: '8px' }}
       borderColor="fuchsia.700"
-      // TODO: Remove borderBottomWidth and borderBottomColor once we fix the issue
-      borderBottomWidth="8px"
-      borderBottomColor="sky.700"
     >
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">


### PR DESCRIPTION
## Changes

- Use new colors
- Make header look more like Figma design
- Make links in header look better and have clearer hover states
- Make drawer look a bit better
- Make drawer open and close icons larger

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

This makes the header look more like the Figma design, though it needs a lot more work before it's 100% equal to the Figma design. So consider this a "first try" at aligning the header to the Figma design. The idea here is to get something better than the current header, that gives a "preview" of the final design.

**Known bad stuff that needs fixing**

- [x] There's some weird issue with the padding on the header box, seems the padding/size of the about/comparator links is messing with the size of the header box. (Start with full width window, resize window with mouse)
- [x] If link is not the active element, borderColor should equal header/drawer background (decided to keep the border but de-emphasize it for not active link element)
- [x] `h1` fontSize should shrink to `16px` on iPhone
- [x] `borderTop` should be `4px` when on iPhone (this is the colored bar on top of the header)