### PR TITLE
Enable color mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,5 +85,5 @@ Do the following to get a ugly button to toggle between light/dark mode:
 
 1. Create a file named `.env.local` in the root of the project (this file is on the `.gitignore` list so it won't be committed accidentally)
 1. Put `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE=true` inside the `.env.local` file.
-1. Stop the development server, and run `yarn start` to restar the server
+1. Stop the development server, and run `yarn start` to restart the server
 1. You can now use the button in the header to switch between light/dark mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,36 @@ Do the following to get a ugly button to toggle between light/dark mode:
 1. Put `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE=true` inside the `.env.local` file.
 1. Stop the development server, and run `yarn start` to restart the server
 1. You can now use the button in the header to switch between light/dark mode
+
+### Setting colors for light/dark mode
+
+You only need to pass 2 values to `useColorModeValue`:
+
+- the first one is the variant for light mode
+- the second one is the variant for dark mode
+
+Save the values in a `const` that will _automagically_ get the corresponding value based on the current color mode.
+You can use this `const` anywhere, but most of the time it will be passed to a Chakra component prop.
+
+You can use `useColorModeValue` as many times you need/want inside a component to generate several variables based on color mode.
+
+### Example in code
+
+Here's an example of how to colorize a component.
+
+1. Create/edit a `const` that contains the colors.
+1. Ue the `const` within a Chakra property.
+
+```typescript
+const Footer = () => {
+  const boxBgColor = useColorModeValue('gray.50', 'gray.900')
+
+  return (
+    <Box as="footer" bg={boxBgColor}>
+      <FluidContainer></FluidContainer>
+    </Box>
+  )
+}
+
+export default Footer
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,3 +75,15 @@ Use the following query string to check the comparator output:
 ```
 ?repo=testing-library%2Fdom-testing-library&from=v6.16.0&to=v8.1.0
 ```
+
+## Working on dark mode locally
+
+We've hidden the color mode behind a feature flag called `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE`.
+This way we can work on the dark mode without publishing the feature.
+
+Do the following to get a ugly button to toggle between light/dark mode:
+
+1. Create a file named `.env.local` in the root of the project (this file is on the `.gitignore` list so it won't be committed accidentally)
+1. Put `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE=true` inside the `.env.local` file.
+1. Stop the development server, and run `yarn start` to restar the server
+1. You can now use the button in the header to switch between light/dark mode

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, HStack, Stack } from '@chakra-ui/react'
+import { Box, Center, HStack, Stack, useColorModeValue } from '@chakra-ui/react'
 import Image from 'next/image'
 
 import poweredByVercelLogo from '@app-public/powered-by-vercel.svg'
@@ -6,49 +6,57 @@ import { REPO_URL } from '~/common'
 import FluidContainer from '~/components/FluidContainer'
 import Link from '~/components/Link'
 
-const Footer = () => (
-  <Box as="footer" bg="gray.50" flexShrink={0}>
-    <FluidContainer py={5}>
-      <Stack justify="space-between" direction={['column', 'row']} spacing={4}>
-        <HStack
-          shouldWrapChildren
+const Footer = () => {
+  const boxBgColor = useColorModeValue('gray.50', 'gray.900')
+
+  return (
+    <Box as="footer" bg={boxBgColor} flexShrink={0}>
+      <FluidContainer py={5}>
+        <Stack
           justify="space-between"
-          alignItems="center"
-          justifyContent="center"
-          fontSize={{ base: 'md', md: 'lg' }}
+          direction={['column', 'row']}
+          spacing={4}
         >
-          <Box>
-            Created with{' '}
-            <span role="img" aria-label="Love">
-              💜
-            </span>{' '}
-            by{' '}
-            <Link isExternal href="https://mario.dev/">
-              Mario
-            </Link>
-          </Box>
-          <Box as="span">-</Box>
-          <Link
-            isExternal
-            href={REPO_URL}
-            title="Octoclairvoyant repository on GitHub"
+          <HStack
+            shouldWrapChildren
+            justify="space-between"
+            alignItems="center"
+            justifyContent="center"
+            fontSize={{ base: 'md', md: 'lg' }}
           >
-            GitHub
-          </Link>
-        </HStack>
-        <Box>
-          <Center>
+            <Box>
+              Created with{' '}
+              <span role="img" aria-label="Love">
+                💜
+              </span>{' '}
+              by{' '}
+              <Link isExternal href="https://mario.dev/">
+                Mario
+              </Link>
+            </Box>
+            <Box as="span">-</Box>
             <Link
               isExternal
-              href="https://vercel.com/?utm_source=octoclairvoyant-team&utm_campaign=oss"
+              href={REPO_URL}
+              title="Octoclairvoyant repository on GitHub"
             >
-              <Image alt="Powered by Vercel logo" src={poweredByVercelLogo} />
+              GitHub
             </Link>
-          </Center>
-        </Box>
-      </Stack>
-    </FluidContainer>
-  </Box>
-)
+          </HStack>
+          <Box>
+            <Center>
+              <Link
+                isExternal
+                href="https://vercel.com/?utm_source=octoclairvoyant-team&utm_campaign=oss"
+              >
+                <Image alt="Powered by Vercel logo" src={poweredByVercelLogo} />
+              </Link>
+            </Center>
+          </Box>
+        </Stack>
+      </FluidContainer>
+    </Box>
+  )
+}
 
 export default Footer

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -67,7 +67,9 @@ const LinksStack = () => (
   >
     <MenuLink href="/">Comparator</MenuLink>
     <MenuLink href="/about">About</MenuLink>
-    <ToggleColorModeButton />
+    {!!process.env.NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE && (
+      <ToggleColorModeButton />
+    )}
     {/* TODO: implement logout if necessary */}
   </Stack>
 )

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,6 +22,7 @@ import { FaBars } from 'react-icons/fa'
 import mascotIcon from '@app-public/mascot-icon.png'
 import FluidContainer from '~/components/FluidContainer'
 import RouteLink from '~/components/RouteLink'
+import ToggleColorModeButton from '~/components/ToggleColorModeButton'
 import useIsClientSide from '~/hooks/useIsClientSide'
 
 const LOGO_SIZES = { base: '25px', md: '30px', lg: '50px' }
@@ -66,6 +67,7 @@ const LinksStack = () => (
   >
     <MenuLink href="/">Comparator</MenuLink>
     <MenuLink href="/about">About</MenuLink>
+    <ToggleColorModeButton />
     {/* TODO: implement logout if necessary */}
   </Stack>
 )

--- a/src/components/ToggleColorModeButton.tsx
+++ b/src/components/ToggleColorModeButton.tsx
@@ -1,0 +1,17 @@
+import { Button, useColorMode } from '@chakra-ui/react'
+
+const ToggleColorModeButton = () => {
+  const { colorMode, toggleColorMode } = useColorMode()
+  const isLightMode = colorMode === 'light'
+
+  return (
+    <Button
+      onClick={toggleColorMode}
+      colorScheme={isLightMode ? 'primary' : 'secondary'}
+    >
+      Toggle {isLightMode ? 'Dark' : 'Light'}
+    </Button>
+  )
+}
+
+export default ToggleColorModeButton

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -1,4 +1,4 @@
-import { ColorHues, extendTheme } from '@chakra-ui/react'
+import { ColorHues, extendTheme, ThemeConfig } from '@chakra-ui/react'
 
 // ***** Legacy colorscheme *****
 
@@ -99,6 +99,11 @@ const tertiaryTextDarkmode = coolGray['400']
 
 // ***** Collect constants, put them in a customTheme *****
 
+const themeConfig: ThemeConfig = {
+  initialColorMode: 'light',
+  useSystemColorMode: true,
+}
+
 const customTheme = extendTheme({
   colors: {
     blue: blueColor,
@@ -124,6 +129,7 @@ const customTheme = extendTheme({
       'html, body, #__next': { height: '100%' },
     },
   },
+  config: themeConfig,
 })
 
 export default customTheme

--- a/src/customTheme.ts
+++ b/src/customTheme.ts
@@ -101,7 +101,7 @@ const tertiaryTextDarkmode = coolGray['400']
 
 const themeConfig: ThemeConfig = {
   initialColorMode: 'light',
-  useSystemColorMode: true,
+  useSystemColorMode: !!process.env.NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE,
 }
 
 const customTheme = extendTheme({

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,4 +1,7 @@
+import { ColorModeScript } from '@chakra-ui/react'
 import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+import customTheme from '~/customTheme'
 
 class MyDocument extends Document {
   render() {
@@ -110,6 +113,9 @@ class MyDocument extends Document {
           />
         </Head>
         <body>
+          <ColorModeScript
+            initialColorMode={customTheme.config.initialColorMode}
+          />
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
## Changes

- Enables color mode to switch between light and dark modes
- Hides the color mode under a feature flag named `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE` to not releasing this to production yet

If you want to enable the color mode locally, you need to:

1. create a file named `.env.local` in the root of the project (this is ignored in the repo so won't be pushed since the target of this file is to set env vars locally)
2. put `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE=true` inside this file
3. restart your local server (i.e. stop `yarn start` and rerun it again)

When we want to release this officially to the production platform it would be as simple as setting the new env var in Vercel for the production environment, and then remove the conditions checking `NEXT_PUBLIC_FEATURE_FLAG_COLOR_MODE` value at some point.

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Closes #240 