### PR TITLE
Improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Report a bug
-labels: 'bug'
+labels: 'bug, status:requirements'
 ---
 
 ## Describe the bug

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.md
@@ -1,7 +1,7 @@
 ---
 name: Feature suggestion
 about: Suggest a new feature
-labels: 'enhancement'
+labels: 'enhancement, status:requirements'
 ---
 
 ## What feature would you like to have?


### PR DESCRIPTION
## Changes

- Add `status:requirements` to any new issue

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

This makes it that when we create a new issue, it has the label `status:requirements`.

The new label `status:` is meant to help give us a better overview of the status of an issue.
The progression of a issue is:

1. Issue gets created with `status:requirements`, usually we need to figure out what we need to do to resolve the issue
2. Once we have a clear idea on how to resolve the issue, we use the `status:ready` label to say: "What we have decided on in the issue is ready to start getting built now"
3. When a issue is being worked on, we use the `status:in-progress` label, so that others know that somebody is working on this.
4. When the issue is done, we could remove the label by hand, but this is optional.

This setup is basically a direct copy/paste from the Renovate bot repository setup.

If you don't want to have this many labels, now is a good time to tell me to stop adding labels! 😄 😉 