### PR TITLE
Set permissions for GitHub Action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

- Set permissions for GitHub Action workflows

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Relevant quote from the [GitHub docs, security hardening for github actions](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions):
 
> - **Use credentials that are minimally scoped**
> 
>     Make sure the credentials being used within workflows have the least privileges required, and be mindful that any user with write access to your repository has read access to all secrets configured in your repository.
>     Actions can use the `GITHUB_TOKEN` by accessing it from the `github.token` context. For more information, see "Context and expression syntax for GitHub Actions." You should therefore make sure that the `GITHUB_TOKEN` is granted the minimum required permissions. It's good security practice to set the default permission for the `GITHUB_TOKEN` to read access only for repository contents. The permissions can then be increased, as required, for individual jobs within the workflow file. For more information, see "Authentication in a workflow."

The way this works is that if you use the `permissions` key, only those permissions listed will be granted, so anything not in the `permissions` list is denied.

The [GitHub docs, authentication in a workflow, permissions for the github token](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) has a nice table with a overview of the permissions you can grant.

It's easy to see what permissions each action was using before this change:

> You can see the permissions that `GITHUB_TOKEN` had for a specific job in the "Set up job" section of the workflow run log. For more information, see "[Using workflow run logs.](https://docs.github.com/en/actions/managing-workflow-runs/using-workflow-run-logs)"

You can check the logs on this PR to review the permissions it uses now. The `metadata` permission is always set to `read` no matter what other permissions you grant/do not grant.