### PR TITLE
Make Octoclairvoyant image link to homepage

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,16 +21,16 @@ const Header = (props: BoxProps) => {
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">
           <Flex alignItems="center">
-            <RouteLink href="/">
-              <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
+            <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
+              <RouteLink href="/">
                 <Image
                   priority
                   src={mascotIcon}
-                  alt="Octoclairvoyant reading a crystal ball"
+                  alt="Go to home page"
                   placeholder="blur"
                 />
-              </Box>
-            </RouteLink>
+              </RouteLink>
+            </Box>
             <Heading
               as="h1"
               color="primaryTextLightmode"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ const Header = (props: BoxProps) => {
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">
           <Flex alignItems="center">
-            <RouteLink href="">
+            <RouteLink href="/">
               <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
                 <Image
                   priority

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,14 +21,16 @@ const Header = (props: BoxProps) => {
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">
           <Flex alignItems="center">
-            <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
-              <Image
-                priority
-                src={mascotIcon}
-                alt="Octoclairvoyant reading a crystal ball"
-                placeholder="blur"
-              />
-            </Box>
+            <RouteLink href="/">
+              <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
+                <Image
+                  priority
+                  src={mascotIcon}
+                  alt="Octoclairvoyant reading a crystal ball"
+                  placeholder="blur"
+                />
+              </Box>
+            </RouteLink>
             <Heading
               as="h1"
               color="primaryTextLightmode"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,16 +21,16 @@ const Header = (props: BoxProps) => {
       <FluidContainer py={5}>
         <Flex justify="space-between" alignItems="center">
           <Flex alignItems="center">
-            <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
-              <RouteLink href="/">
+            <RouteLink href="">
+              <Box h={LOGO_SIZES} w={LOGO_SIZES} mr={2}>
                 <Image
                   priority
                   src={mascotIcon}
                   alt="Go to home page"
                   placeholder="blur"
                 />
-              </RouteLink>
-            </Box>
+              </Box>
+            </RouteLink>
             <Heading
               as="h1"
               color="primaryTextLightmode"


### PR DESCRIPTION
## Changes

- Make Octoclairvoyant image link to homepage

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Fixes #152.

This works, but I'm not sure if this is the best way of doing it. 😄 

The link is actually on the `<Box>` element that has the image in it.