### PR TITLE
Pin GitHub Action digests to specific commit hash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "lockFileMaintenance": {


### PR DESCRIPTION
## Changes

- Pin GitHub Action digests to specific commit hash

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Tag based versioning has a weakness: maintainers can change the commit to which the tag points.
By pinning to the commit hash, we have full control over which version of the action we run.

Read the [GitHub docs, security hardening for github actions, using third party actions](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions), section on "Pin actions to a full length commit SHA".