### PR TITLE
Automerge `@types/*` packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
+  "extends": ["config:base", "helpers:pinGitHubActionDigests", ":automergeTypes"],
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "lockFileMaintenance": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["config:base", "helpers:pinGitHubActionDigests", ":automergeTypes"],
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests",
+    ":automergeTypes"
+  ],
   "dependencyDashboard": true,
   "prCreation": "not-pending",
   "lockFileMaintenance": {


### PR DESCRIPTION
## Changes

- Use Renovate config preset `:automergeTypes` in our `extends:` array

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

This should automerge `@types/*` packages if the tests pass. 😉 

Docs for this preset: https://docs.renovatebot.com/presets-default/#automergetypes