### PR TITLE
Use --frozen-lockfile flag for CI installations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies with yarn
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Make build
         run: yarn build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies with yarn
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Check types
         run: yarn type-check


### PR DESCRIPTION
## Changes

- Use `yarn installl --frozen-lockfile`

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

Turns out we weren't actually forcing the use of the lockfile in our CI installations. This PR ensures that we use the lockfile, and don't modify/update the lockfile in the installation step.

Quote from https://classic.yarnpkg.com/en/docs/cli/install/

> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass `--frozen-lockfile` flag.


