### PR TITLE
Renovate v26 turns on dashboard by default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
     "helpers:pinGitHubActionDigests",
     ":automergeTypes"
   ],
-  "dependencyDashboard": true,
   "prCreation": "not-pending",
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
## Changes

- Remove the `dependencyDashboard` = `true` line

## Context

Renovate `v26` now enables the `dependencyDashboard` in the `config:base` preset.
We do not need to enable the dashboard by hand anymore.