### PR TITLE
Migrate old Cypress tests to use Testing Library features

### DIFF
--- a/cypress/integration/comparator.spec.ts
+++ b/cypress/integration/comparator.spec.ts
@@ -1,2 +1,49 @@
 // TODO: implement e2e for comparator here
+
+// Write new test that fills out the form so that it ends up with the standard comparator query, to confirm our form is functional.
+
+// Ask Belco how to get cy.findByText(/Changes from v6.16.0 to v8.1.0/i).should('exist') to wait for the result.
+// We should mock/fixture the result somehow, as we're expecting the same results each time... and it's really easy to hit the API limits unauthenticated.
+// For now these tests do work properly, but they're not using any Testing Library queries.
+
+it('should show expected results when using standard query string', () => {
+  cy.visit(
+    '/?repo=testing-library%2Fdom-testing-library&from=v6.16.0&to=v8.1.0'
+  )
+
+  // Confirm from and to version range are displayed
+
+  cy.contains('Changes from v6.16.0 to v8.1.0')
+
+  // Confirm versions are mentioned somewhere
+
+  cy.contains('v6.16.0')
+  cy.contains('v8.1.0')
+
+  cy.contains('h2', 'breaking changes')
+
+  cy.contains('span', 'v7.0.0')
+
+  cy.contains('h5', 'Drop Node 8')
+  cy.contains('p', 'Node 10 or greater is required.')
+  cy.contains('a', 'out of LTS')
+  cy.contains('a', '#459')
+  cy.contains('a', 'c3ab843')
+  cy.contains('a', '#430')
+
+  cy.contains('pre', 'devDependencies')
+
+  cy.contains('h2', 'features')
+
+  cy.contains('h2', 'bug fixes')
+
+  cy.contains('h2', 'reverts')
+
+  cy.contains('h2', 'recommendations')
+
+  cy.contains('h2', 'chore')
+})
+
+// Keep the export {} braces here!
+
 export {}

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -1,3 +1,31 @@
+it('should show correct page title', () => {
+  cy.visit('/')
+
+  cy.title().should(
+    'equal',
+    'Homepage | Octoclairvoyant: Compare GitHub changelogs across multiple releases'
+  )
+})
+
+it('should display h1 heading with correct text', () => {
+  cy.visit('/')
+
+  cy.findByRole('heading', { level: 1, name: 'Octoclairvoyant' }).should(
+    'exist'
+  )
+})
+
+it('should display h2 heading with correct text', () => {
+  cy.visit('/')
+
+  cy.findByRole('heading', {
+    level: 2,
+    name: 'Compare GitHub changelogs across multiple releases',
+  }).should('exist')
+})
+
+// TODO: Write test that checks for image being present (alt text is already checked via some other linter).
+
 it('should have a working link to comparator page', () => {
   cy.visit('/')
 
@@ -5,5 +33,16 @@ it('should have a working link to comparator page', () => {
 
   cy.url().should('equal', 'http://localhost:3000/comparator')
 })
+
+// Ask Belco how to get the footer with .findByRole, I can't get it working with footer or with contentinfo.
+
+it('should display footer text', () => {
+  cy.visit('/')
+
+  cy.contains('footer', 'Created with')
+  cy.contains('footer', 'by Mario')
+})
+
+// NOTE: Keep the export {} function below, do not remove it!
 
 export {}


### PR DESCRIPTION
## Changes

- Migrate old Cypress test so that I'm using Testing Library features more often

## Context

<!-- If you're fixing an issue with this pull request, use the Fixes keyword with the issue number you're closing, like this:

Fixes #1
-->

## Todo's:

- [ ] Get review by @Belco90 
- [ ] Implement review feedback/tips and tricks
- [ ] Remove comments that are no longer needed
- [ ] Final review and merge

Closes issue #373.

Marking this as a draft PR, as I need feedback and help! 😉 