### PR TITLE
Create .gitpod.Dockerfile and .gitpod.yml

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,19 @@
+# Based on a file from https://github.com/mikenikles/cypress-on-gitpod
+# Licensed under the MIT license.
+
+FROM gitpod/workspace-full-vnc
+
+# Install Cypress dependencies.
+RUN sudo apt-get update \
+ && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+   libgtk2.0-0 \
+   libgtk-3-0 \
+   libnotify-dev \
+   libgconf-2-4 \
+   libnss3 \
+   libxss1 \
+   libasound2 \
+   libxtst6 \
+   xauth \
+   xvfb \
+ && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,21 @@
+# Based on a file from https://github.com/mikenikles/cypress-on-gitpod with custom changes.
+# Licensed under the MIT license.
+
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: |
+      yarn
+      gp sync-done install
+    command: yarn dev
+  - init: gp sync-await install
+    command: yarn cypress
+  - command: git branch
+ports:
+  - port: 5900
+    onOpen: ignore
+  - port: 6080
+    onOpen: open-browser
+  - port: 10000
+    onOpen: ignore

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 yarn.lock
 .next
 public
+.gitpod.Dockerfile 


### PR DESCRIPTION
## Changes

- Create Gitpod configuration file
- Create Gitpod "Dockerfile"
- Tell Prettier to ignore the `.gitpod.Dockerfile`

## Context

The `.gitpod.Dockerfile` is a real Dockerfile, just with a different name. We need to install some dependencies to make Cypress work with Gitpod.

## License warning

The Gitpod configuration file and the Gitpod "Dockerfile" are based on files from https://github.com/mikenikles/cypress-on-gitpod repository, that uses the MIT license. Not sure if we can mix-and-match with our BSD-2-clause license. To be on the safe side, I've put a license comment in those two files, with a link to the source repository where I basically copy/pasted the code, and then made some customization for our own situation.

## Question for maintainer/author of `mikenikles/cypress-on-gitpod`

Hi @mikenikles, as you can see I'm using 2 files of your repository `cypress-on-gitpod` as a base for our Gitpod configuration. 
I also grabbed the changes that are in a pending PR: https://github.com/mikenikles/cypress-on-gitpod/pull/3

Are you okay for me to use these two files and customize them? By the way, thank you very much for figuring out how to run Cypress on Gitpod, I would not have got that working myself! 😄 

If you want we can keep the MIT license warning in these two files.

Let me know what you like best! 😉 